### PR TITLE
Fix for #33

### DIFF
--- a/java/src/enchcracker/EnchCrackerWindow.java
+++ b/java/src/enchcracker/EnchCrackerWindow.java
@@ -290,9 +290,9 @@ public class EnchCrackerWindow extends JFrame {
 							case 1:
 								xpSeedOutput.setText(String.format("XP seed: %08X", singleSeedCracker.getSeed()));
 								if (xpSeed1TextField.getText().isEmpty()) {
-									xpSeed1TextField.setText(Integer.toHexString(singleSeedCracker.getSeed()));
+									xpSeed1TextField.setText(String.format("%08X", singleSeedCracker.getSeed()));
 								} else if (xpSeed2TextField.getText().isEmpty()) {
-									xpSeed2TextField.setText(Integer.toHexString(singleSeedCracker.getSeed()));
+									xpSeed2TextField.setText(String.format("%08X", singleSeedCracker.getSeed()));
 								}
 								break;
 							default:
@@ -313,11 +313,9 @@ public class EnchCrackerWindow extends JFrame {
 							case 1:
 								xpSeedOutput.setText(String.format("XP seed: %08X", singleSeedCracker.getSeed()));
 								if (xpSeed1TextField.getText().isEmpty()) {
-									xpSeed1TextField.setText(Integer.toHexString(singleSeedCracker.getSeed()));
-								} else {
-									if (xpSeed2TextField.getText().isEmpty()) {
-										xpSeed2TextField.setText(Integer.toHexString(singleSeedCracker.getSeed()));
-									}
+									xpSeed1TextField.setText(String.format("%08X", singleSeedCracker.getSeed()));
+								} else if (xpSeed2TextField.getText().isEmpty()) {
+									xpSeed2TextField.setText(String.format("%08X", singleSeedCracker.getSeed()));
 								}
 								break;
 							default:

--- a/java/src/enchcracker/EnchData.java
+++ b/java/src/enchcracker/EnchData.java
@@ -1,7 +1,5 @@
 package enchcracker;
 
-import java.util.ArrayList;
-
 public class EnchData {
   private int shelves = -1;
   private int s1 = -1;


### PR DESCRIPTION
This addresses issue #33, where automatic copying was done incorrectly.  While the cracker *should* have still worked, this has been fixed for consistency.

An unused import was also removed.