### PR TITLE
Improve and correct German translations

### DIFF
--- a/resources/i18n/EnchantmentCracker_de.properties
+++ b/resources/i18n/EnchantmentCracker_de.properties
@@ -2,58 +2,58 @@
 program.name = Enchantment Cracker
 
 # Tab tooltips on top of the GUI
-tab.enchantmentCracker = Verzauberung-Knacker
-tab.enchantmentCalculator = Verzauberung-Rechner
+tab.enchantmentCracker = Verzauberungs-Knacker
+tab.enchantmentCalculator = Verzauberungs-Rechner
 tab.about = Über
 
 # Enchantment Cracker tab translations
 enchCrack.xpSeed1 = Zauberseed 1
-enchCrack.xpSeed1.tooltip = Der erste aufeinanderfolgenden Zauberseed
+enchCrack.xpSeed1.tooltip = Der erste aufeinanderfolgende Zauberseed
 enchCrack.xpSeed2 = Zauberseed 2
-enchCrack.xpSeed2.tooltip = Der zweite aufeinanderfolgenden Zauberseed
+enchCrack.xpSeed2.tooltip = Der zweite aufeinanderfolgende Zauberseed
 enchCrack.calculate = Seed berechnen
-enchCrack.bookshelves.tooltip = Die Anzahl der Bücherregale, die dem Zaubertisch ausgesetzt
-enchCrack.xpCost1.tooltip = Die Nummer auf der rechten Seite des oberen Platzes
-enchCrack.xpCost2.tooltip = Die Nummer auf der rechten Seite des mittleren Platzes
-enchCrack.xpCost3.tooltip = Die Nummer auf der rechten Seite des unteren Platzes
+enchCrack.bookshelves.tooltip = Die Anzahl der Bücherregale mit Wirkung auf den Zaubertisch
+enchCrack.xpCost1.tooltip = Die Zahl auf der rechten Seite des oberen Slots
+enchCrack.xpCost2.tooltip = Die Zahl auf der rechten Seite des mittleren Slots
+enchCrack.xpCost3.tooltip = Die Zahl auf der rechten Seite des unteren Slots
 enchCrack.check = Prüfen
-enchCrack.check.tooltip = Verwenden diese Angaben, um die mögliche Zauberseeds zu einengen
+enchCrack.check.tooltip = Verwenden Sie diese Angaben, um die möglichen Zauberseeds einzuengen
 enchCrack.reset = Zurücksetzen
-enchCrack.reset.tooltip = Zurücksetzen den Verzauberung-Knacker, um ein neuer Zauberseed knacken werden zu können
-enchCrack.impossible = Keine mögliche Seeds
+enchCrack.reset.tooltip = Setzen Sie den Verzauberungs-Knacker zurück, um einen neuen Zauberseed knacken zu können
+enchCrack.impossible = Keine möglichen Seeds
 enchCrack.result = Zauberseed: %08X
 enchCrack.remaining = Mögliche Seeds: %s
 enchCrack.remaining.thousand = Mögliche Seeds: %sk
 enchCrack.remaining.million = Mögliche Seeds: %sM
 enchCrack.remaining.billion = Mögliche Seeds: %skM
-enchCrack.progress = Progress: %02.0f%%
+enchCrack.progress = Fortschritt: %02.0f%%
 
 # Enchantment Calculator tab translations
 enchCalc.item.tooltip = Der Gegenstand, den Sie verzaubern wollen
 enchCalc.material.tooltip = Das Material des Gegenstands, den Sie verzaubern wollen
-enchCalc.maxBookshelves.tooltip = Die maximale Anzahl der Bücherregale zu benutzen
+enchCalc.maxBookshelves.tooltip = Die maximale Anzahl der zu benutzenden Bücherregale
 enchCalc.calculate = Berechnen
-enchCalc.calculate.tooltip = Pressen Sie, um wie viele Gegenstände, die Sie fallen lassen müsste, um diese Verzauberungen zu bekommen, zu berechnen
-enchCalc.playerSeedNotFound = Sie müssen erstens die Spielerseed knacken!\nGehen Sie rüber zum ersten Tab, um das zu tun.
+enchCalc.calculate.tooltip = Drücken Sie hier, um die Anzahl an Gegenständen zu berechnen, die Sie fallen lassen müssen, um die Verzauberungen zu bekommen
+enchCalc.playerSeedNotFound = Sie müssen erst den Spielerseed knacken!\nWechseln Sie zum ersten Tab, um dies zu tun.
 enchCalc.impossible = Nichts gefunden
 enchCalc.noDummy = Kein Dummy
 enchCalc.stackFormat = 64x%d + %d
 enchCalc.done = Fertig
-enchCalc.done.tooltip = Pressen Sie, um ihm Bescheid, dass Sie diese Verzauberungen gemacht haben, zu geben
-enchCalc.throwCount.tooltip = Die Anzahl der Gegenstände, die fallen lassen werden sollten
-enchCalc.slot.tooltip = Der Platz, mit dem Sie verzaubern sollten
-enchCalc.bookshelves.tooltip = Die Anzahl der Bücherregale, mit den Sie verzaubern sollten
+enchCalc.done.tooltip = Drücken Sie hier, nachdem Sie die Verzauberungen durchgeführt haben
+enchCalc.throwCount.tooltip = Die Anzahl der Gegenstände, die fallen gelassen werden sollen
+enchCalc.slot.tooltip = Der Slot, mit dem Sie verzaubern sollen
+enchCalc.bookshelves.tooltip = Die Anzahl der Bücherregale, mit denen Sie verzaubern sollen
 enchCalc.level = Erfahrungsstufe:
-enchCalc.level.tooltip = Die gegenwärtige Erfahrungsstufe des Spielers. Ermöglicht Verzauberugen, die Stufe 30 und unter haben.
+enchCalc.level.tooltip = Die aktuelle Erfahrungsstufe des Spielers. Ermöglicht, Verzauberungen unterhalb von Stufe 30 zu finden.
 
 # About tab translation
 # End each line with "\n\". Links must be the whole line, and are in the format "LINK <url> <text>".
 # When translating into other languages, make sure to indicate what links are in English, and instruct the user to report bugs in English.
 program.about = Enchantment Cracker %s\n\
   Originalversion von Earthcomputer\n\
-  Optimierung- und Benutzeroberfläche-Verbesserungen von Hexicube\n\
+  Optimierung und Verbesserungen der Benutzeroberfläche von Hexicube\n\
   \n\
-  Lernprogramm und Erläuterung (Englisch):\n\
+  Anleitung und Erläuterung (Englisch):\n\
   LINK https://youtu.be/hfiTZF0hlzw Minecraft, Vanilla Survival: Cracking the Enchantment Seed\n\
   \n\
   Imgur-Album (Englisch):\n\
@@ -62,8 +62,8 @@ program.about = Enchantment Cracker %s\n\
   GitHub-Seite:\n\
   LINK https://github.com/Earthcomputer/EnchantmentCracker Earthcomputer/EnchantmentCracker\n\
   \n\
-  Bitte auf dem Issue-Tracker Fehler, die Sie finden, melden.\n\
-  Stellen Sie sicher, dass Sie die enchcracker.log Datei schließen.
+  Bitte melden Sie Fehler auf dem Issue-Tracker.\n\
+  Stellen Sie sicher, dass Sie die Datei enchcracker.log beifügen.
 
 # Enchantments
 # These should be the same as the official translations of enchantments, abbreviated where too long


### PR DESCRIPTION
The old translation seems to have been done in a rush, as it:
- misses words
- is unclear in some parts
- contains a non-negligable amount of grammatical mistakes

So I looked over it and reworked it accordingly. :smiley:

### Changes
**Most changes are spelling corrections, adjusting word order in sentences and improving grammatics.**

The only actual changes are:
- `Platz` -> `Slot` (the German Minecraft wiki also utilizes the term Slot, for consistency)
- l. 29: `Progress` -> `Fortschritt` (Progress is almost never used, all other software and normal language use Fortschritt)
- `sollten` -> `sollen` (clearer, they _need to_, not they should maybe)
- l. 56: `Lernprogramm` -> `Anleitung` (a tutorial is more like instructions rather than a learning program)
- l. 66: `schließen` -> `beifügen` (schließen is to close, and it should mean include)
