### PR TITLE
DPI scaling is respected in newer java version, which we do not want.

### DIFF
--- a/src/enchcracker/EnchCrackerWindow.java
+++ b/src/enchcracker/EnchCrackerWindow.java
@@ -76,6 +76,7 @@ public class EnchCrackerWindow extends StyledFrameMinecraft {
 	 * Launch the application.
 	 */
 	public static void main(String[] args) {
+		System.setProperty("sun.java2d.uiScale", "1");
 		Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
 			// Write to log
 			Log.fatal("An unexpected error occurred", e);


### PR DESCRIPTION
In java 9+ monitor scaling is respected on swing applications, which we do NOT want as it scales artwork and can make it blurry.

This could eventually be paired with a scaling option in-UI that sets this property, half-integer values work nicely. Ideally it would use whole values, and artwork that isn't starting out at double scale.

Note: A more complex fix is required for java 8, where it listens for changes to the transform matrix on the graphics object.