### PR TITLE
Fixed some seeds being erroneously ignored

### DIFF
--- a/src/enchcracker/cracker/JavaSingleSeedCracker.java
+++ b/src/enchcracker/cracker/JavaSingleSeedCracker.java
@@ -60,7 +60,7 @@ public class JavaSingleSeedCracker extends AbstractSingleSeedCracker {
 		final int halfShelves = bookshelves / 2 + 1;
 		final int shelvesPlusOne = bookshelves + 1;
 
-		final int firstEarly = slot1 * 3 + 1;
+		final int firstEarly = slot1 * 3 + 2;
 		final int secondEarly = slot2 * 3 / 2;
 		final int secondSubOne = slot2 - 1;
 


### PR DESCRIPTION
The first input first slot early exit completely breaks in the 0.5% of cases where the first slot is 2.