### PR TITLE
Prevent divide by 0

### DIFF
--- a/src/enchcracker/cracker/JavaSingleSeedCracker.java
+++ b/src/enchcracker/cracker/JavaSingleSeedCracker.java
@@ -51,7 +51,7 @@ public class JavaSingleSeedCracker extends AbstractSingleSeedCracker {
 	@Override
 	public void firstInput(int bookshelves, int slot1, int slot2, int slot3) {
 		abortRequested.set(false);
-		final int threadCount = Runtime.getRuntime().availableProcessors() - 1; // always leave one for OS
+		final int threadCount = Runtime.getRuntime().availableProcessors() - 1 != 0 ? Runtime.getRuntime().availableProcessors() - 1 : 1; // always leave one for OS; ternary op to ensure that it is never zero
 		final int blockSize = Integer.MAX_VALUE / 20 / threadCount - 1;
 		final AtomicInteger seed = new AtomicInteger(Integer.MIN_VALUE);
 		ArrayList<Thread> threads = new ArrayList<>();

--- a/src/enchcracker/cracker/JavaSingleSeedCracker.java
+++ b/src/enchcracker/cracker/JavaSingleSeedCracker.java
@@ -51,7 +51,7 @@ public class JavaSingleSeedCracker extends AbstractSingleSeedCracker {
 	@Override
 	public void firstInput(int bookshelves, int slot1, int slot2, int slot3) {
 		abortRequested.set(false);
-		final int threadCount = Runtime.getRuntime().availableProcessors() - 1 != 0 ? Runtime.getRuntime().availableProcessors() - 1 : 1; // always leave one for OS; ternary op to ensure that it is never zero
+		final int threadCount = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1); // always leave one for OS but ensure at least 1 processor is used
 		final int blockSize = Integer.MAX_VALUE / 20 / threadCount - 1;
 		final AtomicInteger seed = new AtomicInteger(Integer.MIN_VALUE);
 		ArrayList<Thread> threads = new ArrayList<>();


### PR DESCRIPTION
Added in a ternary operation so that if it evaluates to 0 it will become 1 instead. (The only issue I can see is that the user's computer dies or hangs possibly.. although then everything is running on the same thread/core)

EDIT: Fixes #273 