### PR TITLE
Added zero-padding to seed displays to prevent NumberFormatException

### DIFF
--- a/src/enchcracker/EnchCrackerWindow.java
+++ b/src/enchcracker/EnchCrackerWindow.java
@@ -545,15 +545,14 @@ public class EnchCrackerWindow extends StyledFrameMinecraft {
 				Log.info("Calculate player seed failed, XP seed 2 invalid");
 				return;
 			}
-			Log.info("Calculating player seed with " + Integer.toHexString(xpSeed1) + ", "
-					+ Integer.toHexString(xpSeed2));
+			Log.info(String.format("Calculating player seed with %08x, %08x", xpSeed1, xpSeed2));
 			// Brute force the low bits
 			long seed1High = ((long) xpSeed1 << 16) & 0x0000_ffff_ffff_0000L;
 			long seed2High = ((long) xpSeed2 << 16) & 0x0000_ffff_ffff_0000L;
 			found = false;
 			for (int seed1Low = 0; seed1Low < 65536; seed1Low++) {
 				if ((((seed1High | seed1Low) * 0x5deece66dL + 0xb) & 0x0000_ffff_ffff_0000L) == seed2High) {
-					playerSeed.setText(String.format("%12X", ((seed1High | seed1Low) * 0x5deece66dL + 0xb) & 0x0000_ffff_ffff_ffffL));
+					playerSeed.setText(String.format("%012X", ((seed1High | seed1Low) * 0x5deece66dL + 0xb) & 0x0000_ffff_ffff_ffffL));
 					found = true;
 					break;
 				}

--- a/src/enchcracker/EnchCrackerWindow.java
+++ b/src/enchcracker/EnchCrackerWindow.java
@@ -933,7 +933,7 @@ public class EnchCrackerWindow extends StyledFrameMinecraft {
 			} catch (NumberFormatException e) {
 				Log.info("Could not update player level text");
 			}
-			playerSeed.setText(String.format("%12X", curSeed));
+			playerSeed.setText(String.format("%012X", curSeed));
 			timesNeeded = -2;
 			outDrop.setText("-");
 			outBook.setText("-");


### PR DESCRIPTION
The current formatting in btnCalculate's playerSeed.setText uses %12X, which pads with spaces instead of zeros.

This probably (I didn't run a stack trace) causes a NumberFormatException when parsing if a seed has leading zeros, as the parser cannot handle the spaces in the input string. Replacing this with %012X ensures a valid hex string.

I've also updated the terminal/log output to include leading zeros for better consistency and copy/paste-ability during the cracking process.

Example XP Seeds I came across most recently:
F5926BF4
024CA2DE